### PR TITLE
Add README instructions and build script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "build": "npm install",
+    "launch": "cd backend && python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python app.py && cd .. && npm run dev"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -20,17 +20,57 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
-## Learn More
+## Running the Backend API
 
-To learn more about Next.js, take a look at the following resources:
+To run the backend API, follow these steps:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+1. Navigate to the `backend` directory:
+   ```bash
+   cd backend
+   ```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+2. Create a virtual environment and activate it:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+
+3. Install the required dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Start the backend server:
+   ```bash
+   python app.py
+   ```
+
+The backend server will start on [http://localhost:5000](http://localhost:5000).
 
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+To deploy the backend API on Vercel, follow these steps:
+
+1. Create a `vercel.json` file in the `backend` directory with the following content:
+   ```json
+   {
+     "version": 2,
+     "builds": [
+       { "src": "app.py", "use": "@vercel/python" }
+     ],
+     "routes": [
+       { "src": "/(.*)", "dest": "app.py" }
+     ]
+   }
+   ```
+
+2. Deploy the backend directory to Vercel:
+   ```bash
+   vercel --prod
+   ```
+
+The backend API will be deployed and accessible via the Vercel platform.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,4 +4,3 @@ joblib==1.0.1
 scikit-learn==0.24.2
 numpy==1.21.0
 pandas==1.3.0
-

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build && cd backend && python app.py",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Add instructions for running the backend API and deploying on Vercel in the `README.md` file.

* **README.md**
  - Add instructions for running the backend API, including creating a virtual environment, installing dependencies, and starting the server.
  - Add instructions for deploying the backend API on Vercel, including creating a `vercel.json` file and deploying the backend directory.

* **package.json**
  - Modify the `build` script to include running the backend API.

* **.devcontainer/devcontainer.json**
  - Add a `devcontainer.json` file with tasks for building and launching the project, including setting up the backend API.

* **backend/requirements.txt**
  - Remove extra newline at the end of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kasinadhsarma/foodsafty/pull/2?shareId=979e6320-4d80-4800-8384-a9b0db49cbe8).